### PR TITLE
feat(platform): introduce process group termination and refactor app spawning with route registration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ daemonize = "0.5"
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = [
   "Win32_Foundation",
+  "Win32_System_Diagnostics_ToolHelp",
   "Win32_System_Threading",
   "Win32_Security",
 ] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,9 @@ pub enum NSLError {
         pid: u32,
     },
 
+    #[error("refusing to replace route owned by PID {pid}: {reason}")]
+    UnsafeRouteReplacement { pid: u32, reason: String },
+
     #[error("failed to acquire route lock")]
     LockFailed,
 

--- a/src/hosts/tests.rs
+++ b/src/hosts/tests.rs
@@ -256,6 +256,7 @@ fn test_collect_hostnames_from_routes() {
             change_origin: false,
             path_prefix: "/".to_string(),
             strip_prefix: false,
+            owner: None,
         },
         crate::routes::RouteMapping {
             hostname: "a-app.localhost".to_string(),
@@ -264,6 +265,7 @@ fn test_collect_hostnames_from_routes() {
             change_origin: false,
             path_prefix: "/".to_string(),
             strip_prefix: false,
+            owner: None,
         },
         crate::routes::RouteMapping {
             hostname: "b-app.localhost".to_string(),
@@ -272,6 +274,7 @@ fn test_collect_hostnames_from_routes() {
             change_origin: false,
             path_prefix: "/api".to_string(),
             strip_prefix: false,
+            owner: None,
         },
     ];
 

--- a/src/pages/tests.rs
+++ b/src/pages/tests.rs
@@ -80,6 +80,7 @@ fn test_render_not_found_body_with_routes() {
             change_origin: false,
             path_prefix: "/".to_string(),
             strip_prefix: false,
+            owner: None,
         },
         RouteMapping {
             hostname: "api.localhost".to_string(),
@@ -88,6 +89,7 @@ fn test_render_not_found_body_with_routes() {
             change_origin: true,
             path_prefix: "/api".to_string(),
             strip_prefix: false,
+            owner: None,
         },
     ];
     let body = render_not_found_body("unknown.localhost", &routes);

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -12,6 +12,17 @@ pub fn is_process_alive(pid: u32) -> bool {
     nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid as i32), None).is_ok()
 }
 
+/// Send SIGTERM to an app process group.
+///
+/// On Unix the spawned child is a process group leader (via ProcessGroup::leader()),
+/// so SIGTERM to the group kills the shell and all its descendants (e.g. `next dev`).
+pub fn kill_app_process(pid: u32) {
+    let _ = nix::sys::signal::killpg(
+        nix::unistd::Pid::from_raw(pid as i32),
+        nix::sys::signal::Signal::SIGTERM,
+    );
+}
+
 /// Send SIGTERM to a process. Returns `Ok(())` on success.
 pub fn terminate_process(pid: u32) -> anyhow::Result<()> {
     let nix_pid = nix::unistd::Pid::from_raw(pid as i32);

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -1,6 +1,8 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::routes::RouteOwner;
+
 /// Check if a process is alive by sending signal 0.
 ///
 /// `pid == 0` is treated as "alive" because it represents a static route
@@ -12,15 +14,97 @@ pub fn is_process_alive(pid: u32) -> bool {
     nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid as i32), None).is_ok()
 }
 
-/// Send SIGTERM to an app process group.
-///
-/// On Unix the spawned child is a process group leader (via ProcessGroup::leader()),
-/// so SIGTERM to the group kills the shell and all its descendants (e.g. `next dev`).
-pub fn kill_app_process(pid: u32) {
-    let _ = nix::sys::signal::killpg(
-        nix::unistd::Pid::from_raw(pid as i32),
+pub fn current_platform() -> &'static str {
+    std::env::consts::OS
+}
+
+pub fn current_process_group(pid: u32) -> Option<u32> {
+    nix::unistd::getpgid(Some(nix::unistd::Pid::from_raw(pid as i32)))
+        .ok()
+        .and_then(|pgid| u32::try_from(pgid.as_raw()).ok())
+}
+
+#[cfg(target_os = "linux")]
+pub fn current_process_start_time(pid: u32) -> Option<u64> {
+    let stat = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let after_comm = stat.rsplit_once(") ")?.1;
+    after_comm.split_whitespace().nth(19)?.parse().ok()
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn current_process_start_time(_pid: u32) -> Option<u64> {
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn process_cwd(pid: u32) -> Option<String> {
+    fs::read_link(format!("/proc/{pid}/cwd"))
+        .ok()
+        .map(|p| p.to_string_lossy().into_owned())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn process_cwd(_pid: u32) -> Option<String> {
+    None
+}
+
+fn validate_app_owner(owner: &RouteOwner) -> anyhow::Result<()> {
+    if owner.platform != current_platform() {
+        anyhow::bail!(
+            "route owner platform is {}, current platform is {}",
+            owner.platform,
+            current_platform()
+        );
+    }
+    if !is_process_alive(owner.pid) {
+        anyhow::bail!("route owner process is not alive");
+    }
+    match (owner.process_group, current_process_group(owner.pid)) {
+        (Some(expected), Some(actual)) if expected == actual && actual == owner.pid => {}
+        (Some(expected), Some(actual)) => {
+            anyhow::bail!(
+                "route owner process group changed: expected {}, got {}",
+                expected,
+                actual
+            );
+        }
+        _ => anyhow::bail!("could not verify route owner process group"),
+    }
+
+    if let Some(expected) = owner.start_time {
+        match current_process_start_time(owner.pid) {
+            Some(actual) if actual == expected => {}
+            Some(actual) => {
+                anyhow::bail!(
+                    "route owner start time changed: expected {}, got {}",
+                    expected,
+                    actual
+                );
+            }
+            None => anyhow::bail!("could not verify route owner start time"),
+        }
+    }
+
+    if let Some(cwd) = process_cwd(owner.pid)
+        && cwd != owner.cwd
+    {
+        anyhow::bail!(
+            "route owner cwd changed: expected {}, got {}",
+            owner.cwd,
+            cwd
+        );
+    }
+
+    Ok(())
+}
+
+pub fn kill_app_process(owner: &RouteOwner) -> anyhow::Result<()> {
+    validate_app_owner(owner)?;
+    nix::sys::signal::killpg(
+        nix::unistd::Pid::from_raw(owner.pid as i32),
         nix::sys::signal::Signal::SIGTERM,
-    );
+    )
+    .map_err(|e| anyhow::anyhow!("failed to terminate app process group {}: {}", owner.pid, e))
 }
 
 /// Send SIGTERM to a process. Returns `Ok(())` on success.

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -3,10 +3,16 @@ use std::io::Write as _;
 use std::os::windows::process::CommandExt;
 use std::path::{Path, PathBuf};
 
-use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, STILL_ACTIVE};
+use windows_sys::Win32::Foundation::{
+    CloseHandle, FILETIME, HANDLE, INVALID_HANDLE_VALUE, STILL_ACTIVE,
+};
+use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+    CreateToolhelp32Snapshot, PROCESSENTRY32W, Process32FirstW, Process32NextW, TH32CS_SNAPPROCESS,
+};
 use windows_sys::Win32::System::Threading::{
-    CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, DETACHED_PROCESS, GetExitCodeProcess, OpenProcess,
-    PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE, TerminateProcess,
+    CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, DETACHED_PROCESS, GetExitCodeProcess,
+    GetProcessTimes, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE,
+    TerminateProcess,
 };
 
 use crate::routes::RouteOwner;
@@ -68,8 +74,36 @@ pub fn current_process_group(_pid: u32) -> Option<u32> {
     None
 }
 
-pub fn current_process_start_time(_pid: u32) -> Option<u64> {
-    None
+pub fn current_process_start_time(pid: u32) -> Option<u64> {
+    let handle = ProcessHandle::open(pid, PROCESS_QUERY_LIMITED_INFORMATION)?;
+    let mut creation = FILETIME {
+        dwLowDateTime: 0,
+        dwHighDateTime: 0,
+    };
+    let mut exit = FILETIME {
+        dwLowDateTime: 0,
+        dwHighDateTime: 0,
+    };
+    let mut kernel = FILETIME {
+        dwLowDateTime: 0,
+        dwHighDateTime: 0,
+    };
+    let mut user = FILETIME {
+        dwLowDateTime: 0,
+        dwHighDateTime: 0,
+    };
+
+    // SAFETY: handle is valid; all FILETIME pointers refer to live values.
+    let ok = unsafe { GetProcessTimes(handle.0, &mut creation, &mut exit, &mut kernel, &mut user) };
+    if ok == 0 {
+        return None;
+    }
+
+    Some(filetime_to_u64(creation))
+}
+
+fn filetime_to_u64(time: FILETIME) -> u64 {
+    (u64::from(time.dwHighDateTime) << 32) | u64::from(time.dwLowDateTime)
 }
 
 fn validate_app_owner(owner: &RouteOwner) -> anyhow::Result<()> {
@@ -83,12 +117,73 @@ fn validate_app_owner(owner: &RouteOwner) -> anyhow::Result<()> {
     if !is_process_alive(owner.pid) {
         anyhow::bail!("route owner process is not alive");
     }
+    let Some(expected_start_time) = owner.start_time else {
+        anyhow::bail!("route owner has no process start time");
+    };
+    match current_process_start_time(owner.pid) {
+        Some(actual) if actual == expected_start_time => {}
+        Some(actual) => {
+            anyhow::bail!(
+                "route owner start time changed: expected {}, got {}",
+                expected_start_time,
+                actual
+            );
+        }
+        None => anyhow::bail!("could not verify route owner start time"),
+    }
     Ok(())
 }
 
 pub fn kill_app_process(owner: &RouteOwner) -> anyhow::Result<()> {
     validate_app_owner(owner)?;
-    terminate_process(owner.pid)
+    terminate_process_tree(owner.pid)
+}
+
+pub fn terminate_process_tree(root_pid: u32) -> anyhow::Result<()> {
+    let processes = snapshot_processes().unwrap_or_default();
+    let mut descendants = Vec::new();
+    collect_descendants(root_pid, &processes, &mut descendants);
+
+    for pid in descendants.into_iter().rev() {
+        let _ = terminate_process(pid);
+    }
+
+    terminate_process(root_pid)
+}
+
+fn snapshot_processes() -> anyhow::Result<Vec<(u32, u32)>> {
+    // SAFETY: CreateToolhelp32Snapshot is safe to call with these flags; the
+    // returned handle is checked against INVALID_HANDLE_VALUE.
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        anyhow::bail!("failed to snapshot process tree");
+    }
+    let _snapshot = ProcessHandle(snapshot);
+
+    // SAFETY: PROCESSENTRY32W is a plain C struct. Zero initialization is
+    // valid as long as dwSize is set before calling the ToolHelp APIs.
+    let mut entry: PROCESSENTRY32W = unsafe { std::mem::zeroed() };
+    entry.dwSize = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+
+    let mut processes = Vec::new();
+    // SAFETY: snapshot is valid; entry points to initialized writable memory.
+    let mut ok = unsafe { Process32FirstW(snapshot, &mut entry) };
+    while ok != 0 {
+        processes.push((entry.th32ProcessID, entry.th32ParentProcessID));
+        // SAFETY: snapshot is valid; entry points to initialized writable memory.
+        ok = unsafe { Process32NextW(snapshot, &mut entry) };
+    }
+
+    Ok(processes)
+}
+
+fn collect_descendants(parent_pid: u32, processes: &[(u32, u32)], output: &mut Vec<u32>) {
+    for (pid, parent) in processes {
+        if *parent == parent_pid {
+            output.push(*pid);
+            collect_descendants(*pid, processes, output);
+        }
+    }
 }
 
 /// Terminate a process. Windows has no SIGTERM concept -- this is closer to

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -9,6 +9,8 @@ use windows_sys::Win32::System::Threading::{
     PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE, TerminateProcess,
 };
 
+use crate::routes::RouteOwner;
+
 /// Combined creation flags that fully detach a spawned child: no inherited
 /// console, new process group (so Ctrl+C on the parent doesn't propagate),
 /// and no visible console window.
@@ -58,10 +60,35 @@ pub fn is_process_alive(pid: u32) -> bool {
     exit_code == STILL_ACTIVE as u32
 }
 
-/// Kill an app process by PID. On Windows there is no process-group concept
-/// equivalent to Unix SIGTERM-to-group, so we terminate the process directly.
-pub fn kill_app_process(pid: u32) {
-    let _ = terminate_process(pid);
+pub fn current_platform() -> &'static str {
+    std::env::consts::OS
+}
+
+pub fn current_process_group(_pid: u32) -> Option<u32> {
+    None
+}
+
+pub fn current_process_start_time(_pid: u32) -> Option<u64> {
+    None
+}
+
+fn validate_app_owner(owner: &RouteOwner) -> anyhow::Result<()> {
+    if owner.platform != current_platform() {
+        anyhow::bail!(
+            "route owner platform is {}, current platform is {}",
+            owner.platform,
+            current_platform()
+        );
+    }
+    if !is_process_alive(owner.pid) {
+        anyhow::bail!("route owner process is not alive");
+    }
+    Ok(())
+}
+
+pub fn kill_app_process(owner: &RouteOwner) -> anyhow::Result<()> {
+    validate_app_owner(owner)?;
+    terminate_process(owner.pid)
 }
 
 /// Terminate a process. Windows has no SIGTERM concept -- this is closer to

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -58,6 +58,12 @@ pub fn is_process_alive(pid: u32) -> bool {
     exit_code == STILL_ACTIVE as u32
 }
 
+/// Kill an app process by PID. On Windows there is no process-group concept
+/// equivalent to Unix SIGTERM-to-group, so we terminate the process directly.
+pub fn kill_app_process(pid: u32) {
+    let _ = terminate_process(pid);
+}
+
 /// Terminate a process. Windows has no SIGTERM concept -- this is closer to
 /// SIGKILL, but it matches what users expect from `nsl stop` on Windows.
 pub fn terminate_process(pid: u32) -> anyhow::Result<()> {

--- a/src/proxy/handler.rs
+++ b/src/proxy/handler.rs
@@ -288,6 +288,7 @@ mod tests {
             change_origin: false,
             path_prefix: "/".to_string(),
             strip_prefix: false,
+            owner: None,
         }
     }
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -33,6 +33,24 @@ pub struct RouteMapping {
     /// Strip the matched prefix before forwarding.
     #[serde(default)]
     pub strip_prefix: bool,
+    /// Process identity recorded by `nsl run`.
+    ///
+    /// Older routes and static routes may not have this field. Dynamic routes
+    /// without owner metadata are not eligible for automatic forced cleanup.
+    #[serde(default)]
+    pub owner: Option<RouteOwner>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RouteOwner {
+    pub pid: u32,
+    pub platform: String,
+    pub cwd: String,
+    pub command: Vec<String>,
+    #[serde(default)]
+    pub process_group: Option<u32>,
+    #[serde(default)]
+    pub start_time: Option<u64>,
 }
 
 fn default_path_prefix() -> String {
@@ -111,6 +129,30 @@ impl RouteStore {
         path_prefix: &str,
         strip_prefix: bool,
     ) -> Result<(), NSLError> {
+        self.add_route_with_owner(
+            hostname,
+            port,
+            pid,
+            None,
+            force,
+            change_origin,
+            path_prefix,
+            strip_prefix,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_route_with_owner(
+        &self,
+        hostname: &str,
+        port: u16,
+        pid: u32,
+        owner: Option<RouteOwner>,
+        force: bool,
+        change_origin: bool,
+        path_prefix: &str,
+        strip_prefix: bool,
+    ) -> Result<(), NSLError> {
         self.ensure_dir()?;
         let _lock = self.acquire_lock()?;
 
@@ -129,9 +171,22 @@ impl RouteStore {
                     pid: existing.pid,
                 });
             }
-            // force=true: kill the orphaned app process before replacing the route
-            if existing.pid != 0 && is_process_alive(existing.pid) {
-                crate::platform::kill_app_process(existing.pid);
+
+            if existing.pid != 0 {
+                let owner =
+                    existing
+                        .owner
+                        .as_ref()
+                        .ok_or_else(|| NSLError::UnsafeRouteReplacement {
+                            pid: existing.pid,
+                            reason: "route has no owner metadata".to_string(),
+                        })?;
+                crate::platform::kill_app_process(owner).map_err(|e| {
+                    NSLError::UnsafeRouteReplacement {
+                        pid: existing.pid,
+                        reason: e.to_string(),
+                    }
+                })?;
             }
         }
 
@@ -145,6 +200,7 @@ impl RouteStore {
             change_origin,
             path_prefix: norm_prefix,
             strip_prefix,
+            owner,
         });
 
         self.save_routes(&routes)?;
@@ -170,6 +226,33 @@ impl RouteStore {
             }
             None => {
                 routes.retain(|r| r.hostname != hostname);
+            }
+        }
+        self.save_routes(&routes)?;
+        Ok(())
+    }
+
+    pub fn remove_route_for_pid(
+        &self,
+        hostname: &str,
+        path_prefix: Option<&str>,
+        pid: u32,
+    ) -> Result<(), NSLError> {
+        self.ensure_dir()?;
+        let _lock = self.acquire_lock()?;
+
+        let mut routes = self.load_routes()?;
+        match path_prefix {
+            Some(prefix) => {
+                let norm = normalize_path_prefix(prefix);
+                routes.retain(|r| {
+                    !(r.hostname == hostname
+                        && normalize_path_prefix(&r.path_prefix) == norm
+                        && r.pid == pid)
+                });
+            }
+            None => {
+                routes.retain(|r| !(r.hostname == hostname && r.pid == pid));
             }
         }
         self.save_routes(&routes)?;
@@ -228,6 +311,17 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    fn test_owner(pid: u32) -> RouteOwner {
+        RouteOwner {
+            pid,
+            platform: crate::platform::current_platform().to_string(),
+            cwd: "/tmp/nsl-test".to_string(),
+            command: vec!["sh".to_string(), "-c".to_string(), "sleep 60".to_string()],
+            process_group: None,
+            start_time: None,
+        }
+    }
+
     #[test]
     fn test_add_and_load_route() {
         let tmp = TempDir::new().unwrap();
@@ -246,6 +340,29 @@ mod tests {
     }
 
     #[test]
+    fn test_add_route_with_owner_persists_owner() {
+        let tmp = TempDir::new().unwrap();
+        let store = RouteStore::new(tmp.path().to_path_buf());
+        let owner = test_owner(0);
+
+        store
+            .add_route_with_owner(
+                "myapp.localhost",
+                4000,
+                0,
+                Some(owner.clone()),
+                false,
+                false,
+                "/",
+                false,
+            )
+            .unwrap();
+
+        let routes = store.load_routes().unwrap();
+        assert_eq!(routes[0].owner, Some(owner));
+    }
+
+    #[test]
     fn test_remove_route() {
         let tmp = TempDir::new().unwrap();
         let store = RouteStore::new(tmp.path().to_path_buf());
@@ -257,6 +374,27 @@ mod tests {
 
         let routes = store.load_routes().unwrap();
         assert!(routes.is_empty());
+    }
+
+    #[test]
+    fn test_remove_route_for_pid_does_not_remove_replacement() {
+        let tmp = TempDir::new().unwrap();
+        let store = RouteStore::new(tmp.path().to_path_buf());
+
+        store
+            .add_route("myapp.localhost", 4000, 0, false, false, "/", false)
+            .unwrap();
+        store
+            .add_route("myapp.localhost", 4001, 0, true, false, "/", false)
+            .unwrap();
+
+        store
+            .remove_route_for_pid("myapp.localhost", None, 12345)
+            .unwrap();
+
+        let routes = store.load_routes().unwrap();
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].port, 4001);
     }
 
     #[test]
@@ -279,6 +417,23 @@ mod tests {
             .unwrap();
         let routes = store.load_routes().unwrap();
         assert_eq!(routes[0].port, 4001);
+    }
+
+    #[test]
+    fn test_force_refuses_live_dynamic_route_without_owner() {
+        let tmp = TempDir::new().unwrap();
+        let store = RouteStore::new(tmp.path().to_path_buf());
+        let pid = std::process::id();
+
+        store
+            .add_route("myapp.localhost", 4000, pid, false, false, "/", false)
+            .unwrap();
+
+        let result = store.add_route("myapp.localhost", 4001, 0, true, false, "/", false);
+        assert!(matches!(
+            result,
+            Err(NSLError::UnsafeRouteReplacement { pid: got, .. }) if got == pid
+        ));
     }
 
     #[test]

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -121,13 +121,18 @@ impl RouteStore {
             r.hostname == hostname && normalize_path_prefix(&r.path_prefix) == norm_prefix
         }) && existing.pid != pid
             && (existing.pid == 0 || is_process_alive(existing.pid))
-            && !force
         {
-            return Err(NSLError::RouteConflict {
-                hostname: hostname.to_string(),
-                path_prefix: norm_prefix,
-                pid: existing.pid,
-            });
+            if !force {
+                return Err(NSLError::RouteConflict {
+                    hostname: hostname.to_string(),
+                    path_prefix: norm_prefix,
+                    pid: existing.pid,
+                });
+            }
+            // force=true: kill the orphaned app process before replacing the route
+            if existing.pid != 0 && is_process_alive(existing.pid) {
+                crate::platform::kill_app_process(existing.pid);
+            }
         }
 
         routes.retain(|r| {

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -174,20 +174,6 @@ pub async fn run_app(
         None => find_free_port(config.app_port_range.0, config.app_port_range.1)?,
     };
 
-    // Register route
-    let state_dir = config.resolve_state_dir();
-    let store = RouteStore::new(state_dir);
-    let pid = std::process::id();
-    store.add_route(
-        &hostname,
-        app_port,
-        pid,
-        config.app_force,
-        change_origin,
-        path,
-        strip_prefix,
-    )?;
-
     let url = format_url(
         &hostname,
         config.proxy_port,
@@ -199,14 +185,35 @@ pub async fn run_app(
     // Inject framework flags
     let final_args = replace_port_placeholders(&inject_framework_flags(cmd, app_port), app_port);
 
+    // Build route registration callback — called inside spawn_command right after the child
+    // process is created, so we can store the actual child PID in the route. This ensures
+    // orphaned app processes (nsl killed ungracefully) are detected on subsequent runs.
+    let state_dir_cb = config.resolve_state_dir();
+    let hostname_cb = hostname.clone();
+    let path_cb = path.to_string();
+    let app_force = config.app_force;
+    let on_child_spawned = move |child_pid: u32| {
+        RouteStore::new(state_dir_cb)
+            .add_route(
+                &hostname_cb,
+                app_port,
+                child_pid,
+                app_force,
+                change_origin,
+                &path_cb,
+                strip_prefix,
+            )
+            .map_err(|e| anyhow::anyhow!("{}", e))
+    };
+
     // Spawn the command with process group and await result
-    let result = spawn_command(&final_args, app_port, &url, config, cmd, &hostname, path).await;
+    let result =
+        spawn_command(&final_args, app_port, &url, config, cmd, &hostname, path, on_child_spawned)
+            .await;
 
     // Cleanup route on exit
-    let state_dir = config.resolve_state_dir();
-    let store = RouteStore::new(state_dir);
     let path_filter = if path == "/" { None } else { Some(path) };
-    let _ = store.remove_route(&hostname, path_filter);
+    let _ = RouteStore::new(config.resolve_state_dir()).remove_route(&hostname, path_filter);
 
     match result {
         Ok(0) => Ok(()),
@@ -218,6 +225,11 @@ pub async fn run_app(
 /// Spawn a child process with signal forwarding. On Unix the child is
 /// placed in its own process group so we can signal the whole tree; on
 /// Windows we use a plain tokio `Child` and kill it on Ctrl+C.
+///
+/// `on_child_spawned` is called synchronously with the child PID immediately
+/// after the child is created. If it returns an error the child is killed and
+/// the error is propagated. This lets the caller register a route using the
+/// real child PID rather than the nsl parent PID.
 #[cfg(unix)]
 async fn spawn_command(
     args: &[String],
@@ -227,6 +239,7 @@ async fn spawn_command(
     original_cmd: &[String],
     hostname: &str,
     path: &str,
+    on_child_spawned: impl FnOnce(u32) -> anyhow::Result<()>,
 ) -> anyhow::Result<i32> {
     use process_wrap::tokio::*;
 
@@ -247,6 +260,16 @@ async fn spawn_command(
     let mut child = wrap.spawn()?;
 
     let child_pid = child.id().unwrap_or(0);
+
+    // Register route (or perform any caller-requested setup) using the child PID.
+    // Kill the child immediately if this fails (e.g. route conflict).
+    if let Err(e) = on_child_spawned(child_pid) {
+        let _ = nix::sys::signal::killpg(
+            nix::unistd::Pid::from_raw(child_pid as i32),
+            nix::sys::signal::Signal::SIGTERM,
+        );
+        return Err(e);
+    }
 
     // Wait for app readiness
     if let Err(e) = wait_for_app_wrapped(port, config.ready_timeout, &mut child).await {
@@ -295,6 +318,7 @@ async fn spawn_command(
     original_cmd: &[String],
     hostname: &str,
     path: &str,
+    on_child_spawned: impl FnOnce(u32) -> anyhow::Result<()>,
 ) -> anyhow::Result<i32> {
     use framework::wait_for_app;
 
@@ -306,6 +330,11 @@ async fn spawn_command(
 
     let mut child = cmd.spawn()?;
     let child_pid = child.id().unwrap_or(0);
+
+    if let Err(e) = on_child_spawned(child_pid) {
+        let _ = child.start_kill();
+        return Err(e);
+    }
 
     if let Err(e) = wait_for_app(port, config.ready_timeout, &mut child).await {
         tracing::error!("readiness check failed: {}", e);

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -69,13 +69,18 @@ fn shell_process_command(args: &[String]) -> Vec<String> {
 
 fn build_route_owner(pid: u32, args: &[String]) -> anyhow::Result<RouteOwner> {
     let cwd = std::env::current_dir()?.to_string_lossy().into_owned();
+    let start_time = crate::platform::current_process_start_time(pid);
+    #[cfg(windows)]
+    if start_time.is_none() {
+        anyhow::bail!("could not record route owner process start time");
+    }
     Ok(RouteOwner {
         pid,
         platform: crate::platform::current_platform().to_string(),
         cwd,
         command: shell_process_command(args),
         process_group: crate::platform::current_process_group(pid),
-        start_time: crate::platform::current_process_start_time(pid),
+        start_time,
     })
 }
 
@@ -222,18 +227,19 @@ pub async fn run_app(
     let app_force = config.app_force;
     let on_child_spawned = move |child_pid: u32| {
         let owner = build_route_owner(child_pid, &owner_args)?;
-        RouteStore::new(state_dir_cb)
-            .add_route_with_owner(
-                &hostname_cb,
-                app_port,
-                child_pid,
-                Some(owner),
-                app_force,
-                change_origin,
-                &path_cb,
-                strip_prefix,
-            )
-            .map_err(|e| anyhow::anyhow!("{}", e))?;
+        if let Err(e) = RouteStore::new(state_dir_cb).add_route_with_owner(
+            &hostname_cb,
+            app_port,
+            child_pid,
+            Some(owner.clone()),
+            app_force,
+            change_origin,
+            &path_cb,
+            strip_prefix,
+        ) {
+            let _ = crate::platform::kill_app_process(&owner);
+            return Err(anyhow::anyhow!("{}", e));
+        }
         registered_child_pid_cb.store(child_pid, Ordering::SeqCst);
         Ok(())
     };
@@ -370,13 +376,20 @@ async fn spawn_command(
     let child_pid = child.id().unwrap_or(0);
 
     if let Err(e) = on_child_spawned(child_pid) {
-        let _ = child.start_kill();
+        let _ = crate::platform::terminate_process_tree(child_pid);
         return Err(e);
     }
 
     if let Err(e) = wait_for_app(port, config.ready_timeout, &mut child).await {
         tracing::error!("readiness check failed: {}", e);
-        let _ = child.start_kill();
+        match build_route_owner(child_pid, args) {
+            Ok(owner) => {
+                let _ = crate::platform::kill_app_process(&owner);
+            }
+            Err(_) => {
+                let _ = crate::platform::terminate_process_tree(child_pid);
+            }
+        }
         return Err(e);
     }
 
@@ -388,7 +401,14 @@ async fn spawn_command(
             return Ok(exit_code_from_status(status).unwrap_or(0));
         }
         _ = tokio::signal::ctrl_c() => {
-            let _ = child.start_kill();
+            match build_route_owner(child_pid, args) {
+                Ok(owner) => {
+                    let _ = crate::platform::kill_app_process(&owner);
+                }
+                Err(_) => {
+                    let _ = crate::platform::terminate_process_tree(child_pid);
+                }
+            }
             let status = child.wait().await?;
             return Ok(exit_code_from_status(status).unwrap_or(0));
         }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -2,8 +2,12 @@ mod framework;
 
 use crate::config::Config;
 use crate::discover::infer_project_name;
-use crate::routes::RouteStore;
+use crate::routes::{RouteOwner, RouteStore};
 use crate::utils::{extract_hostname_prefix, format_url, format_urls, parse_hostname};
+use std::sync::{
+    Arc,
+    atomic::{AtomicU32, Ordering},
+};
 
 #[cfg(unix)]
 use framework::wait_for_app_wrapped;
@@ -49,6 +53,30 @@ fn shell_command_line(args: &[String]) -> String {
         .map(|arg| shell_quote(arg))
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+fn shell_process_command(args: &[String]) -> Vec<String> {
+    let joined = shell_command_line(args);
+    #[cfg(unix)]
+    {
+        vec!["sh".to_string(), "-c".to_string(), joined]
+    }
+    #[cfg(windows)]
+    {
+        vec!["cmd".to_string(), "/C".to_string(), joined]
+    }
+}
+
+fn build_route_owner(pid: u32, args: &[String]) -> anyhow::Result<RouteOwner> {
+    let cwd = std::env::current_dir()?.to_string_lossy().into_owned();
+    Ok(RouteOwner {
+        pid,
+        platform: crate::platform::current_platform().to_string(),
+        cwd,
+        command: shell_process_command(args),
+        process_group: crate::platform::current_process_group(pid),
+        start_time: crate::platform::current_process_start_time(pid),
+    })
 }
 
 #[cfg(unix)]
@@ -185,35 +213,52 @@ pub async fn run_app(
     // Inject framework flags
     let final_args = replace_port_placeholders(&inject_framework_flags(cmd, app_port), app_port);
 
-    // Build route registration callback — called inside spawn_command right after the child
-    // process is created, so we can store the actual child PID in the route. This ensures
-    // orphaned app processes (nsl killed ungracefully) are detected on subsequent runs.
+    let registered_child_pid = Arc::new(AtomicU32::new(0));
+    let registered_child_pid_cb = Arc::clone(&registered_child_pid);
     let state_dir_cb = config.resolve_state_dir();
     let hostname_cb = hostname.clone();
     let path_cb = path.to_string();
+    let owner_args = final_args.clone();
     let app_force = config.app_force;
     let on_child_spawned = move |child_pid: u32| {
+        let owner = build_route_owner(child_pid, &owner_args)?;
         RouteStore::new(state_dir_cb)
-            .add_route(
+            .add_route_with_owner(
                 &hostname_cb,
                 app_port,
                 child_pid,
+                Some(owner),
                 app_force,
                 change_origin,
                 &path_cb,
                 strip_prefix,
             )
-            .map_err(|e| anyhow::anyhow!("{}", e))
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
+        registered_child_pid_cb.store(child_pid, Ordering::SeqCst);
+        Ok(())
     };
 
     // Spawn the command with process group and await result
-    let result =
-        spawn_command(&final_args, app_port, &url, config, cmd, &hostname, path, on_child_spawned)
-            .await;
+    let result = spawn_command(
+        &final_args,
+        app_port,
+        &url,
+        config,
+        cmd,
+        &hostname,
+        path,
+        on_child_spawned,
+    )
+    .await;
 
     // Cleanup route on exit
+    let state_dir = config.resolve_state_dir();
+    let store = RouteStore::new(state_dir);
     let path_filter = if path == "/" { None } else { Some(path) };
-    let _ = RouteStore::new(config.resolve_state_dir()).remove_route(&hostname, path_filter);
+    let child_pid = registered_child_pid.load(Ordering::SeqCst);
+    if child_pid != 0 {
+        let _ = store.remove_route_for_pid(&hostname, path_filter, child_pid);
+    }
 
     match result {
         Ok(0) => Ok(()),
@@ -225,11 +270,6 @@ pub async fn run_app(
 /// Spawn a child process with signal forwarding. On Unix the child is
 /// placed in its own process group so we can signal the whole tree; on
 /// Windows we use a plain tokio `Child` and kill it on Ctrl+C.
-///
-/// `on_child_spawned` is called synchronously with the child PID immediately
-/// after the child is created. If it returns an error the child is killed and
-/// the error is propagated. This lets the caller register a route using the
-/// real child PID rather than the nsl parent PID.
 #[cfg(unix)]
 async fn spawn_command(
     args: &[String],
@@ -261,8 +301,6 @@ async fn spawn_command(
 
     let child_pid = child.id().unwrap_or(0);
 
-    // Register route (or perform any caller-requested setup) using the child PID.
-    // Kill the child immediately if this fails (e.g. route conflict).
     if let Err(e) = on_child_spawned(child_pid) {
         let _ = nix::sys::signal::killpg(
             nix::unistd::Pid::from_raw(child_pid as i32),


### PR DESCRIPTION
### Description

This PR resolves previous issues regarding parent-child PID confusion and fragile route conflict handling. It introduces cross-platform process group termination capabilities and improves the robustness of the application lifecycle management.

### Key Changes

- **Cross-platform Process Termination**: Added the `kill_app_process` function to handle process group termination uniformly (sending `SIGTERM` via `killpg` on Unix, and direct termination on Windows).
- **Accurate PID Route Registration**: Introduced the `on_child_spawned` callback mechanism to ensure the real PID is captured immediately after the child process is spawned and used for route registration, completely fixing the previous issue of mistakenly using the parent PID.
- **Robust Route Conflict Handling**: Optimized the `routes` module so that when `force=true` is triggered, it first calls the new function to clean up orphan processes before replacing the route. Additionally, it adds fault tolerance during the registration phase: if the real PID route registration fails, the newly spawned child process is immediately terminated to prevent resource leaks.

### Test Suggestions

- [ ] Verify that on Unix systems, the application process and its child processes are correctly and gracefully terminated (sending SIGTERM).
- [ ] Verify that the process termination logic works correctly on Windows systems.
- [ ] Verify that during normal application startup, the route is bound to the child process's real PID instead of the parent PID.
- [ ] Verify that in a port/route conflict scenario without `force`, the system reports an error as expected.
- [ ] Verify that in a port/route conflict scenario with `force=true`, the occupying process is successfully terminated and the new app starts; simulate a registration failure scenario to confirm the child process is immediately terminated with no zombie processes left behind.

Closes #1 
