### PR TITLE
fix(nsl): keep child in nsl's process group when not interactive

### DIFF
--- a/crates/nsl/src/platform/unix.rs
+++ b/crates/nsl/src/platform/unix.rs
@@ -60,7 +60,7 @@ fn validate_app_owner(owner: &RouteOwner) -> anyhow::Result<()> {
         anyhow::bail!("route owner process is not alive");
     }
     match (owner.process_group, current_process_group(owner.pid)) {
-        (Some(expected), Some(actual)) if expected == actual && actual == owner.pid => {}
+        (Some(expected), Some(actual)) if expected == actual => {}
         (Some(expected), Some(actual)) => {
             anyhow::bail!(
                 "route owner process group changed: expected {}, got {}",
@@ -100,11 +100,19 @@ fn validate_app_owner(owner: &RouteOwner) -> anyhow::Result<()> {
 
 pub fn kill_app_process(owner: &RouteOwner) -> anyhow::Result<()> {
     validate_app_owner(owner)?;
-    nix::sys::signal::killpg(
-        nix::unistd::Pid::from_raw(owner.pid as i32),
-        nix::sys::signal::Signal::SIGTERM,
-    )
-    .map_err(|e| anyhow::anyhow!("failed to terminate app process group {}: {}", owner.pid, e))
+    let nix_pid = nix::unistd::Pid::from_raw(owner.pid as i32);
+    // Only signal the whole process group when the owner is its own group
+    // leader (recorded group id == pid). Otherwise it shares another group
+    // (e.g. nsl ran under a task runner), so we signal only the owner PID to
+    // avoid terminating unrelated processes in the shared group.
+    if owner.process_group == Some(owner.pid) {
+        nix::sys::signal::killpg(nix_pid, nix::sys::signal::Signal::SIGTERM).map_err(|e| {
+            anyhow::anyhow!("failed to terminate app process group {}: {}", owner.pid, e)
+        })
+    } else {
+        nix::sys::signal::kill(nix_pid, nix::sys::signal::Signal::SIGTERM)
+            .map_err(|e| anyhow::anyhow!("failed to terminate app process {}: {}", owner.pid, e))
+    }
 }
 
 /// Send SIGTERM to a process. Returns `Ok(())` on success.
@@ -190,4 +198,47 @@ pub(crate) fn detect_sudo_ids() -> Option<(nix::libc::uid_t, nix::libc::gid_t)> 
     let uid: nix::libc::uid_t = uid_str.parse().ok()?;
     let gid: nix::libc::gid_t = gid_str.parse().ok()?;
     Some((uid, gid))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A child that shares nsl's process group (not its own group leader) must
+    /// still be terminable: `kill_app_process` falls back to signalling the
+    /// single PID instead of bailing or killing the shared group.
+    #[test]
+    fn kill_app_process_terminates_non_leader_owner() {
+        let cwd = process_cwd(std::process::id()).unwrap_or_else(|| {
+            std::env::current_dir()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned()
+        });
+
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .current_dir(&cwd)
+            .spawn()
+            .unwrap();
+        let pid = child.id();
+
+        let owner = RouteOwner {
+            pid,
+            platform: current_platform().to_string(),
+            cwd,
+            command: vec!["sleep".to_string(), "30".to_string()],
+            process_group: current_process_group(pid),
+            start_time: current_process_start_time(pid),
+        };
+
+        // The child inherits the test process's group, so it is not its own
+        // leader: recorded group id differs from its PID.
+        assert_ne!(owner.process_group, Some(pid));
+
+        kill_app_process(&owner).expect("non-leader owner should be killable via single PID");
+
+        let status = child.wait().unwrap();
+        assert!(!status.success(), "child should be terminated by SIGTERM");
+    }
 }

--- a/crates/nsl/src/run/mod.rs
+++ b/crates/nsl/src/run/mod.rs
@@ -275,20 +275,16 @@ pub async fn run_app(
     }
 }
 
-/// Spawn a child process with signal forwarding. On Unix the child is
-/// placed in its own process group so we can signal the whole tree; on
-/// Windows we use a plain tokio `Child` and kill it on Ctrl+C.
+/// Build and spawn the wrapped shell command. When `own_group` is true the
+/// child becomes the leader of a new process group; otherwise it stays in
+/// nsl's own process group.
 #[cfg(unix)]
-async fn spawn_command(
+fn spawn_wrapped(
     args: &[String],
     port: u16,
     url: &str,
-    config: &Config,
-    original_cmd: &[String],
-    hostname: &str,
-    path: &str,
-    on_child_spawned: impl FnOnce(u32) -> anyhow::Result<()>,
-) -> anyhow::Result<i32> {
+    own_group: bool,
+) -> std::io::Result<Box<dyn process_wrap::tokio::ChildWrapper>> {
     use process_wrap::tokio::*;
 
     let shell_cmd = shell_command_line(args);
@@ -303,27 +299,64 @@ async fn spawn_command(
             .env("NSL", "1");
     });
 
-    wrap.wrap(ProcessGroup::leader());
+    if own_group {
+        wrap.wrap(ProcessGroup::leader());
+    }
 
-    let mut child = wrap.spawn()?;
+    wrap.spawn()
+}
+
+/// Terminate the child. When it is its own process group leader we signal the
+/// whole group; otherwise it shares nsl's group, so we signal only the child
+/// PID and let the parent's group cleanup reach the rest of the tree.
+#[cfg(unix)]
+fn terminate_child(own_group: bool, child_pid: u32) {
+    let nix_pid = nix::unistd::Pid::from_raw(child_pid as i32);
+    let _ = if own_group {
+        nix::sys::signal::killpg(nix_pid, nix::sys::signal::Signal::SIGTERM)
+    } else {
+        nix::sys::signal::kill(nix_pid, nix::sys::signal::Signal::SIGTERM)
+    };
+}
+
+/// Spawn a child process with signal forwarding.
+///
+/// When nsl runs interactively (stdin is a TTY), the child is placed in its
+/// own process group so the terminal's Ctrl+C reaches only nsl, which then
+/// forwards the signal deliberately. When nsl runs under a supervisor such as
+/// a task runner (turbo, pnpm), stdin is a pipe: keeping the child in nsl's
+/// own process group lets the supervisor's process-group cleanup reach the
+/// child directly, so it is not orphaned even if nsl is force-killed.
+///
+/// On Windows we use a plain tokio `Child` and kill it on Ctrl+C.
+#[cfg(unix)]
+async fn spawn_command(
+    args: &[String],
+    port: u16,
+    url: &str,
+    config: &Config,
+    original_cmd: &[String],
+    hostname: &str,
+    path: &str,
+    on_child_spawned: impl FnOnce(u32) -> anyhow::Result<()>,
+) -> anyhow::Result<i32> {
+    use std::io::IsTerminal;
+
+    let own_group = std::io::stdin().is_terminal();
+
+    let mut child = spawn_wrapped(args, port, url, own_group)?;
 
     let child_pid = child.id().unwrap_or(0);
 
     if let Err(e) = on_child_spawned(child_pid) {
-        let _ = nix::sys::signal::killpg(
-            nix::unistd::Pid::from_raw(child_pid as i32),
-            nix::sys::signal::Signal::SIGTERM,
-        );
+        terminate_child(own_group, child_pid);
         return Err(e);
     }
 
     // Wait for app readiness
     if let Err(e) = wait_for_app_wrapped(port, config.ready_timeout, &mut child).await {
         tracing::error!("readiness check failed: {}", e);
-        let _ = nix::sys::signal::killpg(
-            nix::unistd::Pid::from_raw(child_pid as i32),
-            nix::sys::signal::Signal::SIGTERM,
-        );
+        terminate_child(own_group, child_pid);
         return Err(e);
     }
 
@@ -331,7 +364,6 @@ async fn spawn_command(
     print_connection_info(config, original_cmd, port, child_pid, hostname, path);
 
     // Set up signal forwarding and wait for child
-    let pgid = nix::unistd::Pid::from_raw(child_pid as i32);
     let mut sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())?;
     let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
 
@@ -343,12 +375,12 @@ async fn spawn_command(
             Ok(exit_code_from_status(status).unwrap_or(0))
         }
         _ = sigint.recv() => {
-            let _ = nix::sys::signal::killpg(pgid, nix::sys::signal::Signal::SIGTERM);
+            terminate_child(own_group, child_pid);
             let status = child.wait().await?;
             Ok(exit_code_from_status(status).unwrap_or(0))
         }
         _ = sigterm.recv() => {
-            let _ = nix::sys::signal::killpg(pgid, nix::sys::signal::Signal::SIGTERM);
+            terminate_child(own_group, child_pid);
             let status = child.wait().await?;
             Ok(exit_code_from_status(status).unwrap_or(0))
         }

--- a/crates/nsl/src/run/tests.rs
+++ b/crates/nsl/src/run/tests.rs
@@ -66,6 +66,58 @@ fn test_is_nsl_disabled_zero() {
     });
 }
 
+/// Poll the process group of `pid` until it matches `want` or the attempts run
+/// out. The child's `setpgid` happens between fork and exec, so the parent may
+/// observe the old group briefly.
+#[cfg(unix)]
+fn wait_for_pgid(pid: u32, want: u32) -> u32 {
+    for _ in 0..50 {
+        if let Some(pgid) = crate::platform::current_process_group(pid)
+            && pgid == want
+        {
+            return pgid;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    crate::platform::current_process_group(pid).unwrap_or(0)
+}
+
+/// Without an own group, the child stays in nsl's process group, so a
+/// supervisor's group-level cleanup (e.g. turbo) reaches it directly and it is
+/// not orphaned if nsl is force-killed.
+#[cfg(unix)]
+#[tokio::test]
+async fn spawn_wrapped_without_own_group_shares_parent_group() {
+    let args = vec!["sleep 30".to_string()];
+    let child = spawn_wrapped(&args, 0, "http://test.local", false).unwrap();
+    let pid = child.id().unwrap();
+
+    let my_pgid = nix::unistd::getpgrp().as_raw() as u32;
+    assert_eq!(crate::platform::current_process_group(pid), Some(my_pgid));
+
+    let _ = nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(pid as i32),
+        nix::sys::signal::Signal::SIGKILL,
+    );
+}
+
+/// With an own group (interactive use), the child leads a new process group so
+/// nsl can forward the terminal's Ctrl+C to the whole tree deliberately.
+#[cfg(unix)]
+#[tokio::test]
+async fn spawn_wrapped_with_own_group_is_leader() {
+    let args = vec!["sleep 30".to_string()];
+    let child = spawn_wrapped(&args, 0, "http://test.local", true).unwrap();
+    let pid = child.id().unwrap();
+
+    assert_eq!(wait_for_pgid(pid, pid), pid);
+
+    let _ = nix::sys::signal::killpg(
+        nix::unistd::Pid::from_raw(pid as i32),
+        nix::sys::signal::Signal::SIGKILL,
+    );
+}
+
 #[test]
 fn test_is_nsl_disabled_skip() {
     with_nsl_env(Some("skip"), || {


### PR DESCRIPTION

When `nsl run <cmd>` is launched by a process supervisor such as `turbo` / `pnpm`, pressing `Ctrl-C` terminates the `nsl` wrapper but leaves the underlying app (e.g. `next dev`) running as an orphan (`ppid=1`), which must then be killed manually by PID.

Process tree under a task runner:

```
turbo (rust)        pgid=A   <- terminal foreground group
 └ pnpm run dev     pgid=B   <- new group created by turbo per task
    └ nsl run next dev   pgid=B
       └ next dev   pgid=C   <- new group created by nsl (ProcessGroup::leader)
          └ next-server pgid=C
```

On Unix, `nsl run` always placed the child in its **own new process group** (`ProcessGroup::leader()`). That is correct for interactive use — it lets `nsl` receive the terminal's `Ctrl-C` and forward it deliberately. But when `nsl` is itself a child of a task runner, the app ends up in a group (C) the runner does not know about. The runner cleans up only the task group it created (B), so the app in group C survives unless `nsl` forwards the signal first.

Under load the runner escalates to `SIGKILL` on group B after a grace timeout. `nsl` is then hard-killed before it can forward, and the app (group C) is orphaned. `SIGKILL` cannot be caught, so a forwarding-based design loses this race. This explains the intermittent nature: a single app shuts down fast enough; many concurrent apps reliably leak.

Reproduced deterministically by sending `SIGKILL` to the task group (what the runner does after its grace period):

```
$ kill -9 -<task_pgid>     # app lives in a SEPARATE group
$ ps -o pid,ppid,pgid,args -p <app_pid>
  <app_pid>  1  <app_pid>  node .../next dev   # survived, ppid=1
```

## Fix

Only create a new process group when `nsl` runs interactively (stdin is a TTY). When stdin is a pipe (running under a supervisor), keep the child in `nsl`'s own process group, so the supervisor's group-level cleanup reaches the child directly — even if `nsl` is force-killed.

- `crates/nsl/src/run/mod.rs`: extract `spawn_wrapped`; gate `ProcessGroup::leader()` on `stdin().is_terminal()`. Signal forwarding (`terminate_child`) uses `killpg` in own-group mode and a single-PID `kill` otherwise.
- `crates/nsl/src/platform/unix.rs`: `kill_app_process` signals the whole group only when the owner is its own group leader (`process_group == pid`), and falls back to a single-PID `kill` otherwise. `validate_app_owner` no longer requires the owner to be a group leader. A shared group is never `killpg`-ed.

Interactive `Ctrl-C` forwarding is unchanged; the orphan only occurred in the non-interactive (supervised) path.

## Verification

- `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test` (all pass).
- New regression tests:
  - child shares the parent group when `own_group=false`; leads its own group when `own_group=true`;
  - `kill_app_process` terminates a non-leader owner via single-PID signal.
- End-to-end: ran the real binary under `setsid` with piped stdin, confirmed the child shares nsl's group, then `kill -9 -<pgid>` on the group — child is reaped with the group, no orphan.

Fixes #3 
